### PR TITLE
Update of leaderboard function and example file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/python:3.5.3
+      - image: circleci/mysql:5.6
+      - image: circleci/mongo:3.0.14
+    steps:
+      - checkout
+      - run: 
+          name: Install Python Dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            cd ~/repo && pip install -e . | tee
+      - run:
+          name: Lint Python Packages
+          command: |
+            . venv/bin/activate
+            flake8 --config=./.flake8 ./
+            find . -iname "*.py" ! -name "setup.py" ! -name "__init__.py" ! -path "./venv/*" | xargs pylint --rcfile=./.pylintrc

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501, E701
+exclude = setup.py, __init__.py, venv

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,8 @@ ENV/
 # mkdocs documentation
 /site
 
+# vim
+.session.vim
+.swp
+
 numerai_datasets/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,8 +1,9 @@
 [MESSAGES CONTROL]
-max-line-length=1000
+max-line-length=120
 max-args=7
 max-attributes=8
-disable=W0141,superfluous-parens,multiple-statements,C0111,C0103,E1101
+max-locals=17
+disable=W0141,superfluous-parens,multiple-statements,C0111,C0103,E1101,logging-format-interpolation
 
 [TYPECHECK]
 ignored-modules = numpy, numpy.random, tensorflow

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MESSAGES CONTROL]
+max-line-length=1000
+max-args=7
+max-attributes=8
+disable=W0141,superfluous-parens,multiple-statements,C0111,C0103,E1101,global-statement,bare-except
+
+[TYPECHECK]
+ignored-modules = numpy, numpy.random, tensorflow
+
+[MISCELLANEOUS]
+notes=XXX

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 max-line-length=1000
 max-args=7
 max-attributes=8
-disable=W0141,superfluous-parens,multiple-statements,C0111,C0103,E1101,global-statement,bare-except
+disable=W0141,superfluous-parens,multiple-statements,C0111,C0103,E1101
 
 [TYPECHECK]
 ignored-modules = numpy, numpy.random, tensorflow

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ If you encounter a problem or have suggestions, feel free to open an issue.
     
   * If you do plan on contributing, clone this repository instead.
 
-2. `cd` into the API directory (defaults to `numerai`, but make sure not to go 
-into the sub-directory also named `numerai`).
+2. `cd` into the API directory (defaults to `numerapi`, but make sure not to go 
+into the sub-directory also named `numerapi`).
 3. `pip install -e .`
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@ if you need further information on the reverse engineering process.
 If you encounter a problem or have suggestions, feel free to open an issue.
 
 # Installation
-This library supports both Python 2 and 3.  Clone this repository, then `cd` 
-into this repository's directory.  Then `pip install -e .`
+1. Obtain a copy of this API
+  * If you do not plan on contributing to this repository, download a release.
+    1. Navigate to [releases](https://github.com/numerai/NumerAPI/releases).
+    2. Download the latest version.
+    3. Extract with `unzip` or `tar` as necessary.
+    
+  * If you do plan on contributing, clone this repository instead.
+
+2. `cd` into the API directory (defaults to `numerai`, but make sure not to go 
+into the sub-directory also named `numerai`).
+3. `pip install -e .`
 
 # Usage
-See the example.py.  You can run it as `./example.py`
+See `example.py`.  You can run it as `./example.py`
 
 # Documentation
 ## Layout

--- a/README.md
+++ b/README.md
@@ -1,76 +1,199 @@
-# Numerai Python API
-Automatically download and upload data for the Numerai machine learning competition
+# NumerAI Python API
+Automatically download and upload data for the Numerai machine learning 
+competition.
 
-This library is a client to the Numerai API. The interface is programmed in Python and allows downloading the training data, uploading predictions, and accessing some user information. Some parts of the code were taken from [numerflow](https://github.com/ChristianSch/numerflow) by ChristianSch. Visit his [wiki](https://github.com/ChristianSch/numerflow/wiki/API-Reverse-Engineering), if you need further information on the reverse engineering process.
+This library is a Python client to the NumerAI API. The interface is programmed 
+in Python and allows downloading the training data, uploading predictions, and 
+accessing user and submission information. Some parts of the code were taken 
+from [numerflow](https://github.com/ChristianSch/numerflow) by ChristianSch.  
+Visit his 
+[wiki](https://github.com/ChristianSch/numerflow/wiki/API-Reverse-Engineering), 
+if you need further information on the reverse engineering process.
 
 If you encounter a problem or have suggestions, feel free to open an issue.
 
 # Installation
-This library supports both Python 2 and 3.  Clone this repository, then `cd` into this repository's directory.  Then `pip install -e .`
+This library supports both Python 2 and 3.  Clone this repository, then `cd` 
+into this repository's directory.  Then `pip install -e .` Using a Virtual 
+Environment is always recommended.
 
 # Usage
 See the example.py.  You can run it as `./example.py`
 
 # Documentation
-### `download_current_dataset`
-#### Parameters
-* `dest_path`: Optional parameter. Destination folder for the dataset. Default: currrent working directory.
-* `unzip`: Optional parameter. Decide if you wish to unzip the downloaded training data. Default: True
+## Layout
+Parameters and return values are given with Python types. Dictionary keys are 
+given in quotes; other names to the left of colons are for reference 
+convenience only. In particular, `list`s of `dict`s have names for the `dict`s; 
+these names will not show up in the actual data, only the actual `dict` data 
+itself.
 
-#### Return values
-* `status_code`: Status code of the requests operation.
-
-### `upload_prediction`
-#### Parameters
-* `file_path`: Path to the prediction. It should already contain the file name ('path/to/file/prediction.csv')
-
-#### Return values
-* `status_code`: Status code of the requests operation.
-
-#### Notes
-* Uploading a prediction shortly before a new dataset is released may result in a <400 Bad Request>. If this happens, just wait for the new dataset and upload new predictions then.
-* Uploading too many predictions in a certain amount of time will result in a <429 Too Many Requests>.
-* Uploading predictions to an account that has 2FA (Two Factor Authentication) enabled is not currently supported
-
-### `get_user`
+## `login`
 ### Parameters
-* `username`: Name of the user you want to request.
+* `email` (`str`, optional): email of user account
+  * will prompt for this value if not supplied
+* `password` (`str`, optional): password of user account
+  * will prompt for this value if not supplied
+  * prompting is recommended for security reasons
+* `prompt_for_mfa` (`bool`, optional): indication of whether to prompt for MFA 
+  code
+  * only necessary if MFA is enabled for user account
+### Return Values
+* `user_credentials` (`dict`): credentials for logged-in user
+  * `"username"` (`str`)
+  * `"access_token"` (`str`)
+  * `"refresh_token"` (`str`)
 
-### Return values
-* `array-like`: Tuple of size nine containing the `username`, `submission_id`, `validation_logloss`, `validation_consistency`, `originality`, `concordance`, `career_usd`, `career_nmr` and the status code of the requests operation. If it fails all values except the status code will be `None`.
-
-### `get_scores`
+## `download_current_dataset`
 ### Parameters
-* `username`: Name of the user you want to request.
+* `dest_path` (`str`, optional, default: `.`): destination folder for the 
+  dataset
+* `unzip` (`bool`, optional, default: `True`): indication of whether the 
+  training data should be unzipped
+### Return Values
+* `success` (`bool`): indication of whether the current dataset was 
+  successfully downloaded
 
-### Return values
-* `array-like`: Tuple of size 2 containing a `numpy.ndarray` containing the scores of all uploaded predictions with the newest first and the status code of the requests operation. If it fails all values except the status code will be `None`.
+## `get_all_competitions`
+### Return Values
+* `all_competitions` (`list`): information about all competitions
+  * `competition` (`dict`)
+    * `"_id"` (`int`)
+        * `"dataset_id"` (`str`)
+        * `"start_date"` (`str (datetime)`)
+        * `"end_date"` (`str (datetime)`)
+        * `"paid"` (`bool`)
+        * `"leaderboard`" (`list`)
+          * `submission` (`dict`)
+            * `"concordant"` (`dict`)
+              * `"pending"` (`bool`)
+              * `"value"` (`bool`)
+            * `"earnings"` (`dict`)
+              * `"career"` (`dict`)
+                * `"nmr"` (`str`)
+                * `"usd"` (`str`)
+              * `"competition"` (`dict`)
+                * `"nmr"` (`str`)
+                * `"usd"` (`str`)
+            * `"logloss"` (`dict`)
+              * `"consistency"` (`int`)
+              * `"validation"` (`float`)
+            * `"original"` (`dict`)
+              * `"pending"` (`bool`)
+              * `"value"` (`bool`)
+            * `"submission_id"` (`str`)
+            * `"username"` (`str`)
 
-### `get_earnings_per_round`
+## `get_competition`
+### Return Values
+* `competition` (`dict`): information about requested competition
+  * `_id` (`int`)
+    * `"dataset_id"` (`str`)
+    * `"start_date"` (`str (datetime)`)
+    * `"end_date"` (`str (datetime)`)
+    * `"paid"` (`bool`)
+    * `"leaderboard"` (`list`)
+      * `submission` (`dict`)
+        * `"concordant"` (`dict`)
+          * `"pending"` (`bool`)
+          * `"value"` (`bool`)
+        * `"earnings"` (`dict`)
+          * `"career"` (`dict`)
+            * `"nmr"` (`str`)
+            * `"usd"` (`str`)
+          * `"competition"` (`dict`)
+            * `"nmr"` (`str`)
+            * `"usd"` (`str`)
+        * `"logloss"` (`dict`)
+          `"consistency"`: (int`)
+          `"validation"`: (float`)
+        * `"original"` (`dict`)
+          * `"pending"` (`bool`)
+          * `"value"` (`bool`)
+        * `"submission_id"` (`str`)
+        * `"username"` (`str`)
+
+## `get_earnings_per_round`
 ### Parameters
-* `username`: Name of the user you want to request.
+* `username`: user for which earnings are requested
+### Return Values
+* `round_ids` (`np.ndarray(int)`): IDs of each round for which there are 
+  earnings
+* `earnings` (`np.ndarray(float)`): earnings for each round
 
-### Return values
-* `array-like`: Tuple of size 2 containing a `numpy.ndarray` containing the earnings of each round with the oldest first and the status code of the requests operation. If it fails all values except the status code will be `None`.
+## `get_scores_for_user`
+### Parameters
+* `username`: user for which scores are being requested
+### Return Values
+* `validation_scores` (`np.ndarray(float)`): logloss validation scores
+* `consistency_scoress` (`np.ndarray(float)`): logloss consistency scores
+* `round_ids` (`np.ndarray(int`): IDs of the rounds for which there are scores
 
-### `login`
-#### Return values
-* `array-like`: Tuple of size four containing the `accessToken`, `refreshToken`, `id`, and the status code of the requests operation. If it fails all values except the status code will be `None`.
+## `get_user`
+### Parameters
+* `username`: `str` - name of requested user
+### Return Values
+* `user` (`dict`): information about the requested user
+  * `"_id"` (`str`)
+  * `"username"` (`str`)
+  * `"assignedEthAddress"` (`str`)
+  * `"created"` (`str (datetime)`)
+  * `"earnings"` (`float`)
+  * `"followers"` (`int`)
+  * `"rewards"` (`list`)
+    * `reward` (`dict`)
+      * `"_id"` (`int`)
+      * `"amount"` (`float`)
+      * `"earned"` (`float`)
+      * `"nmr_earned"` (`str`)
+      * `"start_date"` (`str (datetime)`)
+      * `"end_date"` (`str (datetime)`)
+  * `"submissions"` (`dict`)
+    * `"results"` (`list`)
+      * `result` (`dict`)
+        * `"_id"` (`str`)
+        * `"competition"` (`dict`)
+          * `"_id"` (`str`)
+          * `"start_date"` (`str (datetime)`)
+          * `"end_date"` (`str (datetime)`)
+        * `"competition_id"` (`int`)
+        * `"created"` (`str (datetime)`)
+        * `"id"` (`str`)
+        * `"username"` (`str`)
 
-### `authorize`
-#### Parameters
-* `file_path`: Path to the prediction. It should already contain the file name ('path/to/file/prediction.csv')
+## `get_submission_for_round`
+### Parameters
+* `username` (`str`): user for which submission is requested
+* `round_id` (`int`, optional): round for which submission is requested
+  * if no `round_id` is supplied, the submission for the current round will be 
+    retrieved
+### Return Values
+* `username` (`str`): user for which submission is requested
+* `submission_id` (`str`): ID of submission for which data was found
+* `logloss_val` (`float`): amount of logloss for given submission
+* `logloss_consistency` (`float`): consistency of given submission
+* `career_usd` (`float`): amount of USD earned by given user
+* `career_nmr` (`float`): amount of NMR earned by given user
+* `concordant` (`bool` OR `dict` (see note)): whether given submission is 
+  concordant
+  * for rounds before 64, this was only a boolean, but from 64 on, it is a dict
+    which indicates whether concordance is still being computed
+* `original` (`bool` OR `dict` (see note)): whether given submission is 
+  original
+  * for rounds before 64, this was only a boolean, but from 64 on, it is a dict
+    which indicates whether originality is still being computed
 
-#### Return values
-* `array-like`: Tuple of size four containing the `filename`, `signedRequest`, `headers`, and the status code of the requests operation. If it fails all values except the status code will be `None`.
+## `upload_predictions`
+### Parameters
+* `file_path` (`str`): path to CSV of predictions
+  * should already contain the file name (e.g. `"path/to/file/prediction.csv"`)
 
-### `get_current_competition`
-#### Return values
-* `array-like`: Tuple of size three containing the `dataset_id`, `_id` and the status code of the requests operation. If it fails all values except the status code will be `None`.
+### Return Values
+* `success`: indicator of whether the upload succeeded
 
-### `get_new_leaderboard`
-#### Return Values
-* `list`: A list of every user that has submitted in this round of the competition, including statistics like how much USD and NMR were earned by that user in that round.
-
-#### Notes
-* Each round of the competition is numbered.  The first competition is 1.  Specify a round of the competition to get leaderboard information for that round, or leave off the round of the competition to get the current round of the competition.
+### Notes
+* Uploading a prediction shortly before a new dataset is released may result in 
+  a `400 Bad Request`. If this happens, wait for the new dataset and attempt to 
+  upload again.
+* Uploading too many predictions in a certain amount of time will result in a 
+  `429 Too Many Requests`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# NumerAI Python API
+# Numerai Python API
 Automatically download and upload data for the Numerai machine learning 
 competition.
 
-This library is a Python client to the NumerAI API. The interface is programmed 
+This library is a Python client to the Numerai API. The interface is programmed 
 in Python and allows downloading the training data, uploading predictions, and 
 accessing user and submission information. Some parts of the code were taken 
 from [numerflow](https://github.com/ChristianSch/numerflow) by ChristianSch.  
@@ -14,8 +14,7 @@ If you encounter a problem or have suggestions, feel free to open an issue.
 
 # Installation
 This library supports both Python 2 and 3.  Clone this repository, then `cd` 
-into this repository's directory.  Then `pip install -e .` Using a Virtual 
-Environment is always recommended.
+into this repository's directory.  Then `pip install -e .`
 
 # Usage
 See the example.py.  You can run it as `./example.py`

--- a/example.py
+++ b/example.py
@@ -1,26 +1,66 @@
 #!/usr/bin/env python
+from datetime import datetime
+import json
 
 from numerapi.numerapi import NumerAPI
 
-# Most API calls don't require logging in:
-napi = NumerAPI()
+# set example username and round
+example_username = "xanderai"
+example_round = 51
 
-print("Downloading the current dataset...")
-napi.download_current_dataset(dest_path='.', unzip=True)
+# set up paths for download of dataset and upload of predictions
+now = datetime.now().strftime("%Y%m%d")
+dataset_parent_folder = "./dataset"
+dataset_name = "numerai_dataset_{0}/example_predictions.csv".format(now)
+dataset_path = "{0}/{1}".format(dataset_parent_folder, dataset_name)
 
-# User-specific information
-username = 'xanderai'
-print("Getting information about user {}...".format(username))
-print(napi.get_user(username))
-#print(napi.get_scores(username)) #users api no longer reports scores
-print(napi.get_earnings_per_round(username))
+# most API calls do not require logging in
+napi = NumerAPI(verbosity="info")
 
-# Get the leaderboard for the current round of the competition
-print(napi.get_leaderboard())
+# log in
+credentials = napi.login()
+print(json.dumps(credentials, indent=2))
 
-# Get the leaderboard for previous rounds of the competition
-print(napi.get_leaderboard(64))
+# download current dataset
+dl_succeeded = napi.download_current_dataset(dest_path=dataset_parent_folder,
+    unzip=True)
+print("download succeeded: " + str(dl_succeeded))
 
-# Uploading predicitons to your account require your credentials:
-# napi.credentials = ("YOUR_EMAIL", "YOUR_PASSWORD")
-# napi.upload_prediction('./numerai_datasets/example_predictions.csv')
+# get competitions (returned data is too long to print practically)
+all_comps = napi.get_all_competitions()
+current_comp = napi.get_competition()
+example_comp = napi.get_competition(round_id=example_round)
+
+# get user earnings per round
+user_earnings = napi.get_earnings_per_round()
+print("user earnings:")
+print(user_earnings)
+example_earnings = napi.get_earnings_per_round(username=example_username)
+print("example earnings:")
+print(example_earnings)
+
+# get scores for user
+personal_scores = napi.get_scores_for_user()
+print("personal scores:")
+print(personal_scores)
+other_scores = napi.get_scores_for_user(username=example_username)
+print("other scores:")
+print(other_scores)
+
+# get user information
+current_user = napi.get_user()
+print("current user:")
+print(json.dumps(current_user, indent=2))
+example_user = napi.get_user(username=example_username)
+print("example user:")
+print(json.dumps(example_user, indent=2))
+
+# get submission for given round
+submission = napi.get_submission_for_round(username=example_username,
+        round_id=example_round)
+print("submission:")
+print(json.dumps(submission, indent=2))
+
+# upload predictions
+ul_succeeded = napi.upload_predictions(dataset_path)
+print("upload succeeded: " + str(ul_succeeded))

--- a/example.py
+++ b/example.py
@@ -12,14 +12,14 @@ napi.download_current_dataset(dest_path='.', unzip=True)
 username = 'xanderai'
 print("Getting information about user {}...".format(username))
 print(napi.get_user(username))
-print(napi.get_scores(username))
+#print(napi.get_scores(username)) #users api no longer reports scores
 print(napi.get_earnings_per_round(username))
 
 # Get the leaderboard for the current round of the competition
-print(napi.get_new_leaderboard())
+print(napi.get_leaderboard())
 
 # Get the leaderboard for previous rounds of the competition
-print(napi.get_new_leaderboard(40))
+print(napi.get_leaderboard(64))
 
 # Uploading predicitons to your account require your credentials:
 # napi.credentials = ("YOUR_EMAIL", "YOUR_PASSWORD")

--- a/example.py
+++ b/example.py
@@ -1,66 +1,73 @@
 #!/usr/bin/env python
+
 from datetime import datetime
 import json
 
 from numerapi.numerapi import NumerAPI
 
-# set example username and round
-example_username = "xanderai"
-example_round = 51
 
-# set up paths for download of dataset and upload of predictions
-now = datetime.now().strftime("%Y%m%d")
-dataset_parent_folder = "./dataset"
-dataset_name = "numerai_dataset_{0}/example_predictions.csv".format(now)
-dataset_path = "{0}/{1}".format(dataset_parent_folder, dataset_name)
+def main():
+    # set example username and round
+    example_username = "xanderai"
+    example_round = 51
 
-# most API calls do not require logging in
-napi = NumerAPI(verbosity="info")
+    # set up paths for download of dataset and upload of predictions
+    now = datetime.now().strftime("%Y%m%d")
+    dataset_parent_folder = "./dataset"
+    dataset_name = "numerai_dataset_{0}/example_predictions.csv".format(now)
+    dataset_path = "{0}/{1}".format(dataset_parent_folder, dataset_name)
 
-# log in
-credentials = napi.login()
-print(json.dumps(credentials, indent=2))
+    # most API calls do not require logging in
+    napi = NumerAPI(verbosity="info")
 
-# download current dataset
-dl_succeeded = napi.download_current_dataset(dest_path=dataset_parent_folder,
-    unzip=True)
-print("download succeeded: " + str(dl_succeeded))
+    # log in
+    credentials = napi.login()
+    print(json.dumps(credentials, indent=2))
 
-# get competitions (returned data is too long to print practically)
-all_comps = napi.get_all_competitions()
-current_comp = napi.get_competition()
-example_comp = napi.get_competition(round_id=example_round)
+    # download current dataset
+    dl_succeeded = napi.download_current_dataset(dest_path=dataset_parent_folder,
+                                                 unzip=True)
+    print("download succeeded: " + str(dl_succeeded))
 
-# get user earnings per round
-user_earnings = napi.get_earnings_per_round()
-print("user earnings:")
-print(user_earnings)
-example_earnings = napi.get_earnings_per_round(username=example_username)
-print("example earnings:")
-print(example_earnings)
+    # get competitions (returned data is too long to print practically)
+    # all_competitions = napi.get_all_competitions()
+    # current_competition = napi.get_competition()
+    # example_competition = napi.get_competition(round_id=example_round)
 
-# get scores for user
-personal_scores = napi.get_scores_for_user()
-print("personal scores:")
-print(personal_scores)
-other_scores = napi.get_scores_for_user(username=example_username)
-print("other scores:")
-print(other_scores)
+    # get user earnings per round
+    user_earnings = napi.get_earnings_per_round()
+    print("user earnings:")
+    print(user_earnings)
+    example_earnings = napi.get_earnings_per_round(username=example_username)
+    print("example earnings:")
+    print(example_earnings)
 
-# get user information
-current_user = napi.get_user()
-print("current user:")
-print(json.dumps(current_user, indent=2))
-example_user = napi.get_user(username=example_username)
-print("example user:")
-print(json.dumps(example_user, indent=2))
+    # get scores for user
+    personal_scores = napi.get_scores_for_user()
+    print("personal scores:")
+    print(personal_scores)
+    other_scores = napi.get_scores_for_user(username=example_username)
+    print("other scores:")
+    print(other_scores)
 
-# get submission for given round
-submission = napi.get_submission_for_round(username=example_username,
-        round_id=example_round)
-print("submission:")
-print(json.dumps(submission, indent=2))
+    # get user information
+    current_user = napi.get_user()
+    print("current user:")
+    print(json.dumps(current_user, indent=2))
+    example_user = napi.get_user(username=example_username)
+    print("example user:")
+    print(json.dumps(example_user, indent=2))
 
-# upload predictions
-ul_succeeded = napi.upload_predictions(dataset_path)
-print("upload succeeded: " + str(ul_succeeded))
+    # get submission for given round
+    submission = napi.get_submission_for_round(username=example_username,
+                                               round_id=example_round)
+    print("submission:")
+    print(json.dumps(submission, indent=2))
+
+    # upload predictions
+    ul_succeeded = napi.upload_predictions(dataset_path)
+    print("upload succeeded: " + str(ul_succeeded))
+
+
+if __name__ == "__main__":
+    main()

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -314,7 +314,7 @@ class NumerAPI(object):
                                       leaderboard))
 
             # append scores if any exist for round i
-            if len(submissions) > 0:
+            if submissions:
                 logloss = submissions[0]["logloss"]
                 validation_scores.append(logloss["validation"])
                 consistency_scores.append(logloss["consistency"])

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -82,9 +82,11 @@ class NumerAPI(object):
         rj = r.json()
         rewards = rj['rewards']
         earnings = np.zeros(len(rewards))
+        _id = np.zeros(len(rewards))
         for i in range(len(rewards)):
             earnings[i] = rewards[i]['amount']
-        return (earnings, r.status_code)
+            _id[i] = rewards[i]['_id']
+        return (earnings, _id, r.status_code)
 
 
     def get_scores(self, username):

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -47,6 +47,7 @@ class NumerAPI(object):
         self._not_logged_in_error = ValueError(not_logged_in_msg)
         self._username = None
         self._access_token = None
+        self.url_paths = None
 
     def __get_url(self, url_path_name, query_params=None):
         """get url with query params for Numerai API"""

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -58,15 +58,17 @@ class NumerAPI(object):
         r = requests.get(url)
         return (r.json(), r.status_code)
 
-    def get_leaderboard(self):
+    def get_leaderboard(self, round_id=None):
         now = datetime.now()
         tdelta = timedelta(microseconds=55296e5)
         dt = now - tdelta
         dt_str = dt.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         url = self.leaderboard_url + '?{ leaderboard :'
-        url += ' current , end_date :{ $gt : %s }}'
-        r = requests.get((url % (dt_str)).replace(' ', '%22'))
+        url += ' current , end_date :{ $gt : ' + dt_str + ' }}'
+        if round_id is not None:
+            url = self.leaderboard_url + '/id?{ id :' + str(round_id) + '}'
+        r = requests.get((url).replace(' ', '%22'))
         if r.status_code != 200:
             return (None, r.status_code)
         return (r.json(), r.status_code)

--- a/numerapi/numerapi.py
+++ b/numerapi/numerapi.py
@@ -1,29 +1,31 @@
 # -*- coding: utf-8 -*-
 
+# System
 import zipfile
 import json
 import os
 from datetime import datetime, timedelta
 import getpass
 import errno
-import requests
-import sys
 import logging
-l = logging.getLogger(__name__)
 
+# Third Party
+import requests
 import numpy as np
+
 
 class NumerAPI(object):
 
-    """Wrapper around the NumerAI API"""
+    """Wrapper around the Numerai API"""
 
     def __init__(self, verbosity="INFO"):
         """
-        initialize NumerAI API wrapper for Python
+        initialize Numerai API wrapper for Python
 
         verbosity: indicates what level of messages should be displayed
             valid values: "debug", "info", "warning", "error", "critical"
         """
+        self.logger = logging.getLogger(__name__)
 
         # set up logging
         numeric_log_level = getattr(logging, verbosity.upper())
@@ -32,9 +34,9 @@ class NumerAPI(object):
         log_format = "%(asctime)s %(levelname)s %(name)s: %(message)s"
         self._date_format = "%Y-%m-%dT%H:%M:%S"
         logging.basicConfig(format=log_format, level=numeric_log_level,
-            datefmt=self._date_format)
+                            datefmt=self._date_format)
 
-        # NumerAI API base URL
+        # Numerai API base URL
         self.api_base_url = "https://api.numer.ai"
 
         # first round to check for scores
@@ -43,14 +45,16 @@ class NumerAPI(object):
         # error indicating user is not logged in
         not_logged_in_msg = "username not specified and not logged in"
         self._not_logged_in_error = ValueError(not_logged_in_msg)
+        self._username = None
+        self._access_token = None
 
     def __get_url(self, url_path_name, query_params=None):
-        """get url with query params for NumerAI API"""
+        """get url with query params for Numerai API"""
 
         # mappings of URL path names to URL paths
         self.url_paths = {
             "login": "/sessions",
-            "auth": "/submission_authorizations", 
+            "auth": "/submission_authorizations",
             "dataset": "/competitions/current/dataset",
             "submissions": "/submissions",
             "users": "/users",
@@ -60,23 +64,23 @@ class NumerAPI(object):
         }
 
         # set query params based on type
-        if query_params == None:
+        if query_params is None:
             query_params_str = ""
         elif isinstance(query_params, dict):
             query_params_str = "?" + json.dumps(query_params)
         elif isinstance(query_params, str):
             query_params_str = "?" + query_params
         else:
-            l.warning("invalid query params")
+            self.logger.warning("invalid query params")
             query_params = ""
 
-        return (self.api_base_url
-                + self.url_paths[url_path_name]
-                + query_params_str)
+        return (self.api_base_url +
+                self.url_paths[url_path_name] +
+                query_params_str)
 
     def __get_username(self, username):
         """set username if logged in and not specified"""
-        if username == None:
+        if username is None:
             if hasattr(self, "_username"):
                 username = self._username
             else:
@@ -86,7 +90,7 @@ class NumerAPI(object):
 
     def __unzip_file(self, src_path, dest_path, filename):
         """unzips file located at src_path into destination_path"""
-        l.info("unzipping file...")
+        self.logger.info("unzipping file...")
 
         # construct full path (including file name) for unzipping
         unzip_path = "{0}/{1}".format(dest_path, filename)
@@ -106,11 +110,11 @@ class NumerAPI(object):
 
     def __authorize_file_upload(self, file_path):
         """authorize file upload"""
-        l.info("authorizing file upload...")
+        self.logger.info("authorizing file upload...")
 
         # user must be logged in in order to upload files
         if not hasattr(self, "_access_token"):
-            l.error("you must log in first")
+            self.logger.error("you must log in first")
             self.login()
 
         # set up request parameters
@@ -125,7 +129,7 @@ class NumerAPI(object):
 
         # send auth request
         auth_res = requests.post(auth_url, data=auth_data,
-            headers=auth_headers)
+                                 headers=auth_headers)
         auth_res.raise_for_status()
 
         # parse auth response
@@ -137,12 +141,12 @@ class NumerAPI(object):
 
     def login(self, email=None, password=None, mfa_enabled=False):
         """log user in and store credentials"""
-        l.info("logging in...")
+        self.logger.info("logging in...")
 
         # get login parameters if necessary
-        if email == None:
+        if email is None:
             email = input("email: ")
-        if password == None:
+        if password is None:
             password = getpass.getpass("password: ")
         mfa_code = None
         if mfa_enabled:
@@ -171,11 +175,11 @@ class NumerAPI(object):
 
     def download_current_dataset(self, dest_path=".", unzip=True):
         """download dataset for current round
-        
+
         dest_path: desired location of dataset file
         unzip: indicates whether to unzip dataset
         """
-        l.info("downloading current dataset...")
+        self.logger.info("downloading current dataset...")
 
         # set up download path
         now = datetime.now().strftime("%Y%m%d")
@@ -207,7 +211,7 @@ class NumerAPI(object):
 
     def get_all_competitions(self):
         """get all competitions from first round stored in instance variable"""
-        l.info("getting all competitions...")
+        self.logger.info("getting all competitions...")
 
         # get latest round to determine end of round ID range
         current_round = self.get_competition()
@@ -223,7 +227,7 @@ class NumerAPI(object):
 
     def get_competition(self, round_id=None):
         """get a specific competiton, defaults to most recent"""
-        l.info("getting competition...")
+        self.logger.info("getting competition...")
 
         # set up request URL
         # defaults to getting most recent round
@@ -264,7 +268,7 @@ class NumerAPI(object):
 
     def get_earnings_per_round(self, username=None):
         """get earnings for every round"""
-        l.info("getting earnings...")
+        self.logger.info("getting earnings...")
 
         # construct user request URL
         username = self.__get_username(username)
@@ -288,7 +292,7 @@ class NumerAPI(object):
 
     def get_scores_for_user(self, username=None):
         """get scores for specified user"""
-        l.info("getting scores for user...")
+        self.logger.info("getting scores for user...")
 
         # get all competitions
         competitions = self.get_all_competitions()
@@ -305,8 +309,8 @@ class NumerAPI(object):
             # get submissions for user for round i
             competition = competitions[i]
             leaderboard = competition["leaderboard"]
-            submissions = list(filter(lambda s: s["username"]==username,
-                leaderboard))
+            submissions = list(filter(lambda s: s["username"] == username,
+                                      leaderboard))
 
             # append scores if any exist for round i
             if len(submissions) > 0:
@@ -324,7 +328,7 @@ class NumerAPI(object):
 
     def get_user(self, username=None):
         """get user information"""
-        l.info("getting user...")
+        self.logger.info("getting user...")
 
         # construct user request URL
         username = self.__get_username(username)
@@ -341,7 +345,7 @@ class NumerAPI(object):
 
     def get_submission_for_round(self, username=None, round_id=None):
         """gets submission for single round"""
-        l.info("getting user submission for round...")
+        self.logger.info("getting user submission for round...")
 
         # get username for filtering competition leaderboard
         username = self.__get_username(username)
@@ -355,8 +359,8 @@ class NumerAPI(object):
                 submission_id = user["submission_id"]
                 logloss_val = np.float(user["logloss"]["validation"])
                 logloss_consistency = np.float(user["logloss"]["consistency"])
-                career_usd = np.float(user["earnings"]["career"]["usd"].replace(",",""))
-                career_nmr = np.float(user["earnings"]["career"]["nmr"].replace(",",""))
+                career_usd = np.float(user["earnings"]["career"]["usd"].replace(",", ""))
+                career_nmr = np.float(user["earnings"]["career"]["nmr"].replace(",", ""))
                 concordant = user["concordant"]
                 original = user["original"]
 
@@ -364,12 +368,12 @@ class NumerAPI(object):
                         career_usd, career_nmr, concordant, original)
 
         # return an empty tuple if user is not on the leaderboard
-        l.warning("user \"{0}\" is not on leaderboard".format(username))
+        self.logger.warning("user \"{0}\" is not on leaderboard".format(username))
         return ()
 
     def upload_predictions(self, file_path):
         """uploads predictions from file"""
-        l.info("uploading prediction...")
+        self.logger.info("uploading prediction...")
 
         # parse information for file upload
         filename, signed_url, headers = self.__authorize_file_upload(file_path)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 setup(
     name="numerapi",
-    install_requires=["numpy", "flake8", "pylint"],
+    install_requires=["numpy", "flake8", "pylint", "requests"],
     packages=["numerapi"]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 setup(
     name="numerapi",
-    install_requires=["numpy"],
+    install_requires=["numpy", "flake8", "pylint"],
     packages=["numerapi"]
 )


### PR DESCRIPTION
The example file was using get_new_leaderboard which is going to a broken api endpoint that Numerai have indicated shouldn't be used. I updated get_leaderboard to take an option round_id argument and it now works with the current leaderboard format (rounds 51 to present). Also commented out the get_scores call as that API endpoint no longer seems to report any round scores. It could be updated to loop over past leaderboards and pull scores, though that's not very efficient.